### PR TITLE
Fix cross-platform compatibility: Replace 'which' with platform-specific command on Windows

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,9 @@ export async function decideGeminiCliCommand(
   allowNpx: boolean,
 ): Promise<{ command: string; initialArgs: string[] }> {
   return new Promise((resolve, reject) => {
-    const child = spawn("which", ["gemini"]);
+    const isWindows = process.platform === "win32";
+    const whichCmd = isWindows ? "where" : "which";
+    const child = spawn(whichCmd, ["gemini"]);
     child.on("close", (code) => {
       if (code === 0) {
         resolve({ command: "gemini", initialArgs: [] });


### PR DESCRIPTION
## Summary
Fixed cross-platform compatibility issue where the application failed on Windows due to using the `which` command, which doesn't exist on Windows systems.

## Problem
- The application was using `spawn("which", ["gemini"])` to check if gemini-cli is installed
- Windows doesn't have the `which` command, causing `ENOENT: no such file or directory, uv_spawn 'which'` error
- This prevented the application from running on Windows systems

## Solution
- Added platform detection using `process.platform === "win32"`
- Use `where` command on Windows and `which` command on Unix-like systems
- Maintains the same functionality across all platforms

## Changes
- Modified `decideGeminiCliCommand()` function in `index.ts`
- Added platform-specific command selection logic
- No breaking changes to the API

## Testing
- Tested on Windows 11: Uses `where gemini` command
- Tested on Ubuntu: Uses `which gemini` command
- Both platforms now work correctly

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)