### PR TITLE
refactor\!: change package name from @choplin/mcp-gemini-cli to mcp-gemini-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This server exposes three tools that interact with Gemini CLI:
 ### 1. Add the MCP server
 
 ```bash
-claude mcp add -s project gemini-cli -- npx @choplin/mcp-gemini-cli --allow-npx
+claude mcp add -s project gemini-cli -- npx mcp-gemini-cli --allow-npx
 ```
 
 Or configure your MCP client with the settings shown in the Installation Options section below.
@@ -41,7 +41,7 @@ Example prompts:
   "mcpServers": {
     "mcp-gemini-cli": {
       "command": "npx",
-      "args": ["@choplin/mcp-gemini-cli", "--allow-npx"]
+      "args": ["mcp-gemini-cli", "--allow-npx"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@choplin/mcp-gemini-cli",
+  "name": "mcp-gemini-cli",
   "version": "0.2.0",
   "description": "MCP server wrapper for Google's Gemini CLI",
   "author": "choplin",


### PR DESCRIPTION
## Summary

Change npm package name from scoped `@choplin/mcp-gemini-cli` to unscoped `mcp-gemini-cli`.

## Breaking Changes

⚠️ **This is a breaking change** - Package name has changed:
- From: `@choplin/mcp-gemini-cli`
- To: `mcp-gemini-cli`

## Changes

- Updated package.json name field
- Updated all npx commands in README
- Updated installation instructions

## Migration Guide

Users need to update their MCP configuration:

```json
// Before
{
  "mcpServers": {
    "mcp-gemini-cli": {
      "command": "npx",
      "args": ["@choplin/mcp-gemini-cli", "--allow-npx"]
    }
  }
}

// After
{
  "mcpServers": {
    "mcp-gemini-cli": {
      "command": "npx",
      "args": ["mcp-gemini-cli", "--allow-npx"]
    }
  }
}
```

Claude Code users should update their command:
```bash
# Before
claude mcp add -s project gemini-cli -- npx @choplin/mcp-gemini-cli --allow-npx

# After
claude mcp add -s project gemini-cli -- npx mcp-gemini-cli --allow-npx
```

## Note

This change requires publishing to npm under the new unscoped package name `mcp-gemini-cli`.