### PR TITLE
chore: release 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,20 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 This project is licensed under the MIT License - see the LICENSE file for details.
 
+## 📋 Changelog
+
+### [1.0.0] - 2025-07-02
+
+#### Breaking Changes
+- Tool names: `geminiChat` → `chat`, `geminiAnalyzeFile` → `analyzeFile`
+- Package name: `@choplin/mcp-gemini-cli` → `mcp-gemini-cli`
+
+#### New Features
+- `analyzeFile` tool for images (PNG/JPG/GIF/etc), PDFs, and text files
+
+### [0.2.0] - Previous
+- Initial release with `googleSearch` and `geminiChat` tools
+
 ## 🔗 Related Links
 
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)

--- a/README.md
+++ b/README.md
@@ -214,16 +214,19 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 ## 📋 Changelog
 
-### [1.0.0] - 2025-07-02
+### [0.3.0] - 2025-07-02
 
 #### Breaking Changes
+
 - Tool names: `geminiChat` → `chat`, `geminiAnalyzeFile` → `analyzeFile`
 - Package name: `@choplin/mcp-gemini-cli` → `mcp-gemini-cli`
 
 #### New Features
+
 - `analyzeFile` tool for images (PNG/JPG/GIF/etc), PDFs, and text files
 
 ### [0.2.0] - Previous
+
 - Initial release with `googleSearch` and `geminiChat` tools
 
 ## 🔗 Related Links

--- a/index.ts
+++ b/index.ts
@@ -282,7 +282,7 @@ async function main() {
 
   const server = new McpServer({
     name: "mcp-gemini-cli",
-    version: "1.0.0",
+    version: "0.3.0",
   });
 
   // Register googleSearch tool

--- a/index.ts
+++ b/index.ts
@@ -282,7 +282,7 @@ async function main() {
 
   const server = new McpServer({
     name: "mcp-gemini-cli",
-    version: "0.2.0",
+    version: "1.0.0",
   });
 
   // Register googleSearch tool

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-gemini-cli",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "MCP server wrapper for Google's Gemini CLI",
   "author": "choplin",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-gemini-cli",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "MCP server wrapper for Google's Gemini CLI",
   "author": "choplin",
   "license": "MIT",


### PR DESCRIPTION
## Release 0.3.0

Breaking changes release with new features\! 🚀

### What's Changed

- **Breaking**: Tool names simplified (`geminiChat` → `chat`, `geminiAnalyzeFile` → `analyzeFile`)
- **Breaking**: Package name changed (`@choplin/mcp-gemini-cli` → `mcp-gemini-cli`)
- **New**: `analyzeFile` tool for images, PDFs, and text files
- **Improved**: Code formatting and error messages

See [CHANGELOG](https://github.com/choplin/mcp-gemini-cli/blob/release/0.3.0/README.md#-changelog) for details.

### Publishing

After merge, publish to npm:
```bash
npm publish --access public
```

Note: Since the package name changed, this will be published as a new package `mcp-gemini-cli`.